### PR TITLE
Fixes to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "devDependencies": {
     "@commitlint/cli": "19.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@commitlint/cli": "19.2.0",
     "@commitlint/config-conventional": "19.1.0",
     "@types/node": "20.11.28",
+    "@types/three": "^0.163.0",
     "@typescript-eslint/eslint-plugin": "7.2.0",
     "@typescript-eslint/parser": "7.2.0",
     "eslint": "8.57.0",
@@ -46,7 +47,9 @@
     "lint-staged": "15.2.2",
     "prettier": "3.2.5",
     "typescript": "5.4.2",
-    "vite": "5.1.7"
+    "vite": "5.1.7",
+    "vite-plugin-css-injected-by-js": "^3.5.0",
+    "vite-plugin-dts": "^3.8.3"
   },
   "engines": {
     "node": ">=18.17.0"
@@ -58,11 +61,8 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@types/three": "^0.163.0",
     "lil-gui": "^0.19.2",
-    "three": "^0.163.0",
-    "vite-plugin-css-injected-by-js": "^3.5.0",
-    "vite-plugin-dts": "^3.8.3"
+    "three": "^0.163.0"
   },
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "lil-gui": "^0.19.2",
     "three": "^0.163.0"
   },
+  "peerDependencies": {
+    "three": "^0.163.0"
+  },
   "directories": {
     "lib": "lib"
   }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,14 @@
   "module": "dist/three-infinite-grid.js",
   "exports": {
     ".": {
-      "import": "dist/three-infinite-grid.js",
-      "require": "dist/three-infinite-grid.umd.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/three-infinite-grid.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/three-infinite-grid.umd.cjs"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
- Typescript finds `three-infinite-grid.d.ts` file instead of `index.d.ts`, which breaks for `PLANE`.
- husky warns about the install command being deprecated.
- `@types` and Vite plugins are only needed during build/dev.
- Having `three` as a peer dependency lets the calling code decide the Three version, avoiding conflicts.